### PR TITLE
feat: add GS116Ev2

### DIFF
--- a/src/py_netgear_plus/models.py
+++ b/src/py_netgear_plus/models.py
@@ -613,6 +613,18 @@ class JGS524Ev2(JGSxxxSeries):
     ]
 
 
+class GS116Ev2(JGSxxxSeries):
+    """Definition for Netgear GS116Ev2 model."""
+
+    MODEL_NAME = "GS116Ev2"
+    PORTS = 16
+    POE_PORTS: ClassVar = []
+    CHECKS_AND_RESULTS: ClassVar = [
+        ("check_login_form_rand", [False]),
+        ("parse_first_script_tag", ["GS116Ev2"]),
+    ]
+
+
 MODELS = [
     GS105E,
     GS105Ev2,
@@ -631,4 +643,5 @@ MODELS = [
     JGS516PE,
     JGS524Ev2,
     XS512EM,
+    GS116Ev2,
 ]

--- a/src/py_netgear_plus/parsers.py
+++ b/src/py_netgear_plus/parsers.py
@@ -1135,6 +1135,14 @@ class JGS524Ev2(JGSxxxSeries):
         super().__init__()
 
 
+class GS116Ev2(JGSxxxSeries):
+    """Parser for the GS116Ev2 switch."""
+
+    def __init__(self) -> None:
+        """Initialize the GS116Ev2 parser."""
+        super().__init__()
+
+
 PARSERS = {
     "GS105E": GS105E,
     "GS105Ev2": GS105Ev2,
@@ -1154,4 +1162,5 @@ PARSERS = {
     "JGS516PE": JGS516PE,
     "JGS524Ev2": JGS524Ev2,
     "XS512EM": XS512EM,
+    "GS116Ev2": GS116Ev2,
 }


### PR DESCRIPTION
The GS116Ev2 runs the same firmware as the already supported JGS516PE : (https://kb.netgear.com/000066399/JGS516PE-GS116Ev2-Firmware-Version-2-6-0-50)