### PR TITLE
Add reboot function to GS316EPP

### DIFF
--- a/src/py_netgear_plus/models.py
+++ b/src/py_netgear_plus/models.py
@@ -654,13 +654,6 @@ class GS316EPP(GS316EP):
         ("check_login_form_rand", [True]),
         ("parse_login_title_tag", ["GS316EPP"]),
     ]
-    SWITCH_REBOOT_TEMPLATES: ClassVar = [
-        {
-            "method": "post",
-            "url": "http://{ip}/iss/specific/sys_reload.html",
-            "params": {"Gambit": "_gambit", "ACTION": "literal:Reload"},
-        }
-    ]
 
 
 class JGSxxxSeries(AutodetectedSwitchModel):


### PR DESCRIPTION
The main changes add reboot details for rebooting the netgear gs316EPP switches running firmware 2.0.0.5 and a minor change correcting what I think is a typo.

Please note the code changes I have done were with the help of Gemini, hence I would appreciate a review to confirm the changes are in the correct location. 

I can confirm they work for GS316EPP running firmware 2.0.0.5. I sourced the html page data and payload information required when manually rebooting from the browser and applied them to a downloaded version of the repository in the models.py file and ran it using python. 

I then added the modified repository to the ha-netgear-plus installation managed by ckarrie in my custom components in home assistant and changed some of the ha-netgear-plus files to look at the local version of py_netgear_plus. A reboot button appeared for the GS316EPP in home assistant and when it is clicked the switch reboots. Thus I think it is okay to merge into the main code. 

What I am unsure about is that I have added the details twice, once in the generic class gs316series section and then lower down in the class gs316EPP section. I am not sure if it should be put in both in your main code. Thank you for creating the repository to enable such functionality in home assistant.