### PR TITLE
Set v1.0.0.9 as minimum supported version for MS305E and MS308E

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ some basic configuration updates.
 | GS316EPP  | 16    | V1.0.4.4                               |                     |
 | JGS516PE  | 16    | V2.6.0.48                              |                     |
 | JGS24Ev2  | 24    | V2.6.0.48                              |                     |
-| MS305E    | 5     | ?                                      |                     |
+| MS305E    | 5     | v1.0.0.9                               |                     |
 | MS308E    | 8     | v1.0.0.9                               |                     |
 | XS512EM   | 12    | V1.0.2.8                               |                     |
 


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file, specifying the firmware version for the `MS305E` device. 

* Added the firmware version (`v1.0.0.9`) for `MS305E` in the device table in `README.md`.