### PR TITLE
fix: guard script[0].text against None in _is_authenticated

### DIFF
--- a/src/py_netgear_plus/fetcher.py
+++ b/src/py_netgear_plus/fetcher.py
@@ -300,7 +300,7 @@ class PageFetcher:
             script = html.fromstring(response.content).xpath(
                 '//script[contains(text(),"/wmi/login")]'
             )
-            if len(script) > 0 and 'top.location.href = "/wmi/login"' in script[0].text:
+            if len(script) > 0 and script[0].text and 'top.location.href = "/wmi/login"' in script[0].text:
                 _LOGGER.info(
                     "[PageFetcher._is_authenticated] Returning false: script=%s",
                     script[0].text,

--- a/src/py_netgear_plus/fetcher.py
+++ b/src/py_netgear_plus/fetcher.py
@@ -300,7 +300,11 @@ class PageFetcher:
             script = html.fromstring(response.content).xpath(
                 '//script[contains(text(),"/wmi/login")]'
             )
-            if len(script) > 0 and script[0].text and 'top.location.href = "/wmi/login"' in script[0].text:
+            if (
+                len(script) > 0
+                and script[0].text
+                and 'top.location.href = "/wmi/login"' in script[0].text
+            ):
                 _LOGGER.info(
                     "[PageFetcher._is_authenticated] Returning false: script=%s",
                     script[0].text,


### PR DESCRIPTION
## Summary

In `_is_authenticated`, `script[0].text` can be `None` when the switch returns an unexpected HTML response (e.g. an empty `<script>` tag). This causes an `AttributeError` at the substring test on line 303.

The existing code already guards `title[0].text` against `None` (lines 290–293), but `script[0].text` was missed. This PR adds the same guard.

**Before:**
```python
if len(script) > 0 and 'top.location.href = "/wmi/login"' in script[0].text:
```

**After:**
```python
if len(script) > 0 and script[0].text and 'top.location.href = "/wmi/login"' in script[0].text:
```

Related to: #160 (MS305E/MS308E instability report, where this error was observed in the wild)

*— Ada, AI assistant acting on behalf of [@foxey](https://github.com/foxey)*