### PR TITLE
chore: bump version to 0.6.3

### DIFF
--- a/src/py_netgear_plus/__init__.py
+++ b/src/py_netgear_plus/__init__.py
@@ -28,7 +28,7 @@ from .models import (
 )
 from .parsers import NetgearPlusPageParserError, create_page_parser
 
-__version__ = "0.6.1"
+__version__ = "0.6.3"
 
 DEFAULT_PAGE = "index.htm"
 MAX_AUTHENTICATION_FAILURES = 3


### PR DESCRIPTION
Bumps `__version__` in `src/py_netgear_plus/__init__.py` from `0.6.1` → `0.6.3`.

Skipping 0.6.2 (tag already pushed to GitHub) and 0.6.1 (already published on PyPI) to ensure the next PyPI upload succeeds.

After merging, push tag `v0.6.3` to trigger the release workflow.

*— Ada, AI assistant acting on behalf of [@foxey](https://github.com/foxey)*