### PR TITLE
Add GS308E bootloader V1.00.02 to API_V2_CHECKS allow-list

### DIFF
--- a/src/py_netgear_plus/parsers.py
+++ b/src/py_netgear_plus/parsers.py
@@ -15,7 +15,7 @@ from .utils import get_all_child_classes_dict
 _LOGGER = logging.getLogger(__name__)
 
 API_V2_CHECKS = {
-    "bootloader": ["V1.00.03", "V2.06.01", "V2.06.02", "V2.06.03", "V1.6.0.2-VB"],
+    "bootloader": ["V1.00.02", "V1.00.03", "V2.06.01", "V2.06.02", "V2.06.03", "V1.6.0.2-VB"],
     "firmware": ["V2.06.24GR", "V2.06.24EN", "V1.6.0.17"],
 }
 

--- a/src/py_netgear_plus/parsers.py
+++ b/src/py_netgear_plus/parsers.py
@@ -15,7 +15,14 @@ from .utils import get_all_child_classes_dict
 _LOGGER = logging.getLogger(__name__)
 
 API_V2_CHECKS = {
-    "bootloader": ["V1.00.02", "V1.00.03", "V2.06.01", "V2.06.02", "V2.06.03", "V1.6.0.2-VB"],
+    "bootloader": [
+        "V1.00.02",
+        "V1.00.03",
+        "V2.06.01",
+        "V2.06.02",
+        "V2.06.03",
+        "V1.6.0.2-VB",
+    ],
     "firmware": ["V2.06.24GR", "V2.06.24EN", "V1.6.0.17"],
 }
 


### PR DESCRIPTION
## Summary

Fixes `InvalidPortStatusError: Number of statusses (0) not equal to number of ports(8)` on the GS308E running firmware V1.00.11EN with bootloader **V1.00.02** (reported in #178).

## Root cause

`has_api_v2()` gates port-status table parsing and returns True only when the switch's bootloader OR firmware string is in the hardcoded `API_V2_CHECKS` allow-list. The bootloader is read verbatim from the switch info page (`//td[@id="loader"]`), so it's an exact string match. The reporter has two GS308E units on the same firmware (V1.00.11EN):

- bootloader **V1.00.03** -> in the list -> `has_api_v2()` True -> parses correctly.
- bootloader **V1.00.02** -> not in the list, and V1.00.11EN isn't in the firmware list either -> `has_api_v2()` False -> the port-status table is skipped -> 0 statuses -> `InvalidPortStatusError`.

## Change

Add `"V1.00.02"` to `API_V2_CHECKS["bootloader"]`. Minimal, one-line fix that flips `has_api_v2()` to True for the affected unit. No other behavior changes.

## Testing

Confirmed working: the reporter in #178 applied this exact change, restarted Home Assistant, and all 8 ports now report correctly.

Closes #178