### PR TITLE
Add port switching support for GS305E

### DIFF
--- a/src/py_netgear_plus/models.py
+++ b/src/py_netgear_plus/models.py
@@ -294,6 +294,21 @@ class GS305E(AutodetectedSwitchModel):
         {"method": "get", "url": "http://{ip}/portStatistics.cgi"},
     ]
 
+    SWITCH_PORT_TEMPLATES: ClassVar = [
+        {
+            "method": "post",
+            "url": "http://{ip}/status.cgi",
+            "params": {"hash": "_client_hash"},
+        }
+    ]
+
+    def get_switch_port_data(self, port: int, state: str) -> dict:
+        """Build form data for switching port state via SPEED field."""
+        return {
+            f"port{port}": "checked",
+            "SPEED": 1 if state == "on" else 2,
+        }
+
 
 class GS308E(AutodetectedSwitchModel):
     """Definition for Netgear GS308E model."""


### PR DESCRIPTION
Add regular port enable/disable support for GS305E.
Tested on a physical GS305E running firmware V1.0.0.25. All automated tests pass.

Addresses GS305E model from https://github.com/ckarrie/ha-netgear-plus/issues/243