### PR TITLE
Add support for updating port settings on GS308EP

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,33 @@ print(data)
 sw.turn_off_poe_port(1) # Supported only on PoE capable models
 sw.turn_on_poe_port(1)
 ```
+
+### Port settings
+
+On supported models, selected port settings can be changed while unspecified
+settings are preserved:
+
+```python
+from py_netgear_plus import PORT_SPEED_DISABLED
+
+sw.set_port_settings(
+    8,
+    name="Office PC",
+    speed=PORT_SPEED_DISABLED,
+    flow_control=False,
+)
+```
+
+`set_port_name(port, name)` remains available as a convenience wrapper around
+`set_port_settings()`.
+
+Port-speed constants and their underlying API values are:
+
+| Constant | API value | Setting |
+| --- | ---: | --- |
+| `PORT_SPEED_AUTO` | `1` | Auto |
+| `PORT_SPEED_DISABLED` | `2` | Disabled |
+| `PORT_SPEED_10_HALF` | `3` | 10M half duplex |
+| `PORT_SPEED_10_FULL` | `4` | 10M full duplex |
+| `PORT_SPEED_100_HALF` | `5` | 100M half duplex |
+| `PORT_SPEED_100_FULL` | `6` | 100M full duplex |

--- a/src/py_netgear_plus/__init__.py
+++ b/src/py_netgear_plus/__init__.py
@@ -29,7 +29,7 @@ from .models import (
 )
 from .parsers import NetgearPlusPageParserError, create_page_parser
 
-__version__ = "0.6.4"
+__version__ = "1.0.0"
 
 DEFAULT_PAGE = "index.htm"
 MAX_AUTHENTICATION_FAILURES = 3

--- a/src/py_netgear_plus/__init__.py
+++ b/src/py_netgear_plus/__init__.py
@@ -29,7 +29,7 @@ from .models import (
 )
 from .parsers import NetgearPlusPageParserError, create_page_parser
 
-__version__ = "1.0.0"
+__version__ = "0.6.4"
 
 DEFAULT_PAGE = "index.htm"
 MAX_AUTHENTICATION_FAILURES = 3

--- a/src/py_netgear_plus/__init__.py
+++ b/src/py_netgear_plus/__init__.py
@@ -38,6 +38,14 @@ PORT_MODUS_SPEED = ["Auto"]
 SWITCH_STATES = ["on", "off"]
 FLOW_CONTROL = ["Enable", "Disable"]
 
+# Port speed values used by supported Netgear Plus switch web interfaces.
+PORT_SPEED_AUTO = 1
+PORT_SPEED_DISABLED = 2
+PORT_SPEED_10_HALF = 3
+PORT_SPEED_10_FULL = 4
+PORT_SPEED_100_HALF = 5
+PORT_SPEED_100_FULL = 6
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -766,31 +774,61 @@ class NetgearSwitchConnector:
         )
         return self._page_parser.parse_port_settings(response)
 
-    def set_port_name(self, port: int, name: str) -> bool:
-        """Rename a port, preserving other port settings."""
+    def set_port_settings(  # noqa: PLR0913
+        self,
+        port: int,
+        *,
+        name: str | None = None,
+        speed: int | None = None,
+        flow_control: int | bool | str | None = None,
+        ingress_rate: int | None = None,
+        egress_rate: int | None = None,
+    ) -> bool:
+        """Update selected settings for a port, preserving unspecified values."""
         if not self.switch_model.PORT_SETTINGS_TEMPLATES:
-            message = "Port renaming is not supported on this model"
+            message = "Port settings cannot be changed on this model"
             raise NotImplementedError(message)
 
         all_settings = self.get_port_settings()
         if port not in all_settings:
             message = f"Port {port} not found on switch"
             raise PortNumberOutofRangeError(message)
-        cur = all_settings[port]
+        current = all_settings[port]
+
+        selected_flow_control = (
+            current["flow_control"] if flow_control is None else flow_control
+        )
+        normalized_flow_control = _normalize_flow_control(selected_flow_control)
+        if normalized_flow_control is None:
+            message = f"Invalid flow control value: {selected_flow_control!r}"
+            raise ValueError(message)
+
+        # The POST template requires a client hash. Load it automatically so
+        # callers can write settings immediately after logging in.
+        if not self._client_hash:
+            self._get_switch_metadata()
 
         for template in self.switch_model.PORT_SETTINGS_TEMPLATES:
             url = template["url"].format(ip=self.host)
             method = template["method"]
             data = self.switch_model.get_port_settings_data(
                 port=port,
-                description=name,
-                speed=cur["speed"],
-                flow_control=cur["flow_control"],
-                ingress_rate=cur["ingress_rate"],
-                egress_rate=cur["egress_rate"],
+                description=current["name"] if name is None else name,
+                speed=current["speed"] if speed is None else speed,
+                flow_control=normalized_flow_control,
+                ingress_rate=(
+                    current["ingress_rate"]
+                    if ingress_rate is None
+                    else ingress_rate
+                ),
+                egress_rate=(
+                    current["egress_rate"]
+                    if egress_rate is None
+                    else egress_rate
+                ),
                 priority=0,
             )
-            _LOGGER.debug("set_port_name data=%s", data)
+            _LOGGER.debug("set_port_settings data=%s", data)
             self._page_fetcher.set_data_from_template(template, self, data)
 
             response = BaseResponse
@@ -810,9 +848,13 @@ class NetgearSwitchConnector:
             if isinstance(content, (bytes, str)):
                 content = content.strip()
             _LOGGER.warning(
-                "NetgearSwitchConnector.set_port_name response was %s", content
+                "NetgearSwitchConnector.set_port_settings response was %s", content
             )
         return False
+
+    def set_port_name(self, port: int, name: str) -> bool:
+        """Rename a port, preserving other port settings."""
+        return self.set_port_settings(port, name=name)
 
     def get_ip_config(self) -> dict[str, Any]:
         """Return current IP/DHCP configuration."""

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -10,6 +10,7 @@ import requests
 import requests.cookies
 from py_netgear_plus import (
     DEFAULT_PAGE,
+    PORT_SPEED_DISABLED,
     NetgearSwitchConnector,
     _from_bytes_to_megabytes,
 )
@@ -1432,5 +1433,107 @@ def test_capability_matrix() -> None:
         assert not m.has_password_change(), cls.__name__
 
 
+def _make_port_settings_connector() -> NetgearSwitchConnector:
+    """Return a GS308EP connector prepared for port-setting write tests."""
+    connector = NetgearSwitchConnector(host="192.168.0.1", password="password")
+    connector.switch_model = GS308EP()
+    connector._client_hash = "test-hash"
+    connector.get_port_settings = Mock(  # type: ignore[method-assign]
+        return_value={
+            8: {
+                "name": "Old name",
+                "speed": 1,
+                "flow_control": 2,
+                "ingress_rate": 1,
+                "egress_rate": 1,
+            }
+        }
+    )
+    connector._page_fetcher.set_data_from_template = (  # type: ignore[method-assign]
+        Mock()
+    )
+    response = Mock(status_code=requests.codes.ok, content=b"SUCCESS")
+    connector._page_fetcher.request = (  # type: ignore[method-assign]
+        Mock(return_value=response)
+    )
+    return connector
+
+
+def test_set_port_settings_preserves_unspecified_values() -> None:
+    """Changing one setting preserves all other current port values."""
+    connector = _make_port_settings_connector()
+
+    assert connector.set_port_settings(8, speed=6)
+
+    connector._page_fetcher.request.assert_called_once_with(
+        "post",
+        "http://192.168.0.1/port_status.cgi",
+        {
+            "port8": "checked",
+            "DESCRIPTION": "Old name",
+            "SPEED": "6",
+            "FLOW_CONTROL": "2",
+            "IngressRate": "1",
+            "EgressRate": "1",
+            "priority": "0",
+        },
+    )
+
+
+def test_set_port_settings_can_disable_port() -> None:
+    """The documented disabled-speed value is sent unchanged."""
+    connector = _make_port_settings_connector()
+
+    assert connector.set_port_settings(8, speed=PORT_SPEED_DISABLED)
+
+    data = connector._page_fetcher.request.call_args.args[2]
+    assert data["SPEED"] == str(PORT_SPEED_DISABLED)
+
+
+def test_set_port_settings_updates_multiple_values() -> None:
+    """The generic writer passes all requested values to the model builder."""
+    connector = _make_port_settings_connector()
+
+    assert connector.set_port_settings(
+        8,
+        name="TESTPORT",
+        speed=6,
+        flow_control=True,
+        ingress_rate=10,
+        egress_rate=2,
+    )
+
+    data = connector._page_fetcher.request.call_args.args[2]
+    assert data == {
+        "port8": "checked",
+        "DESCRIPTION": "TESTPORT",
+        "SPEED": "6",
+        "FLOW_CONTROL": "1",
+        "IngressRate": "10",
+        "EgressRate": "2",
+        "priority": "0",
+    }
+
+
+def test_set_port_name_uses_generic_port_settings_writer() -> None:
+    """The existing public rename method remains backward compatible."""
+    connector = _make_port_settings_connector()
+    connector.set_port_settings = Mock(return_value=True)  # type: ignore[method-assign]
+
+    assert connector.set_port_name(8, "TESTPORT")
+    connector.set_port_settings.assert_called_once_with(8, name="TESTPORT")
+
+
+def test_set_port_settings_rejects_unsupported_model() -> None:
+    """Models without port-setting templates remain unaffected."""
+    connector = NetgearSwitchConnector(host="192.168.0.1", password="password")
+    connector.switch_model = GS316EPP()
+    connector._page_fetcher.request = Mock()  # type: ignore[method-assign]
+
+    with pytest.raises(NotImplementedError):
+        connector.set_port_settings(1, speed=1)
+
+    connector._page_fetcher.request.assert_not_called()
+    
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
## Summary

This PR adds support for updating port settings on GS308EP.

### New functionality

- Add `set_port_settings()` for updating:
  - Port name
  - Speed / enabled state
  - Flow control
  - Ingress rate limit
  - Egress rate limit
- Add port speed constants.
- Refactor `set_port_name()` to use the generic port-settings implementation.

### Implementation details

- Preserves existing values for settings that are not specified.
- Lazily loads switch metadata when required.
- Raises `NotImplementedError` on unsupported switch models.
- Normalizes flow-control values.

### Testing

The full test suite passes:

```text
174 passed, 13 skipped